### PR TITLE
Implement Terraform entity with basic CLI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ test-output/
 ignored
 *.iml
 *.log.zip
-.DS_STORE
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test-output/
 ignored
 *.iml
 *.log.zip
+.DS_STORE

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 				  </supportedProjectTypes>
 				  <instructions>
 					  <!-- OSGi specific instruction -->
-					  <Import-Package>!io.airlift,!com.maxmind.geoip2,!com.google.api.client,*</Import-Package>
+					  <Import-Package>!io.airlift.command,!com.maxmind.geoip2,!com.google.api.client,*</Import-Package>
 				  </instructions>
 			  </configuration>
 		  </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 				  <descriptors>
 					  <descriptor>src/main/assembly/assembly.xml</descriptor>
 				  </descriptors>
-				  <finalName>brooklyn-spark</finalName>
+				  <finalName>brooklyn-terraform</finalName>
 			  </configuration>
 			  <executions>
 				  <execution>

--- a/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
@@ -60,4 +60,6 @@ public interface TerraformConfiguration extends SoftwareProcess {
 
     @Effector(description="Performs the Terraform destroy command which will destroy all of the infrastructure that has been previously created by the configuration.")
     void destroy();
+
+    boolean isConfigurationApplied();
 }

--- a/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
@@ -1,9 +1,23 @@
 package io.cloudsoft.terraform;
 
 import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
 @ImplementedBy(TerraformConfigurationImpl.class)
 public interface TerraformConfiguration extends SoftwareProcess {
 
+    @SetFromFlag("configurationContents")
+    public static final ConfigKey<String> CONFIGURATION_CONTENTS = ConfigKeys.newStringConfigKey(
+            "configuration.contents",
+            "Contents of the configuration file that will be applied by Terraform.",
+            "");
+
+    @SetFromFlag("configurationUrl")
+    public static final ConfigKey<String> CONFIGURATION_URL = ConfigKeys.newStringConfigKey(
+            "configuration.url",
+            "URL of the configuration file that will be applied by Terraform.",
+            "");
 }

--- a/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
@@ -24,7 +24,7 @@ public interface TerraformConfiguration extends SoftwareProcess {
 
     @SetFromFlag("downloadUrl")
     BasicAttributeSensorAndConfigKey<String> DOWNLOAD_URL = new StringAttributeSensorAndConfigKey(
-            Attributes.DOWNLOAD_URL, "https://dl.bintray.com/mitchellh/terraform/terraform_${version}_darwin_amd64.zip");
+            Attributes.DOWNLOAD_URL, "https://dl.bintray.com/mitchellh/terraform/terraform_${version}_${driver.osTag}.zip");
 
     @SetFromFlag("tfConfigurationContents")
     ConfigKey<String> CONFIGURATION_CONTENTS = ConfigKeys.newStringConfigKey(

--- a/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
@@ -1,23 +1,38 @@
 package io.cloudsoft.terraform;
 
 import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey;
+import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey.StringAttributeSensorAndConfigKey;
+import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
 @ImplementedBy(TerraformConfigurationImpl.class)
 public interface TerraformConfiguration extends SoftwareProcess {
 
+    @SetFromFlag("version")
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.6.3");
+
+    @SetFromFlag("downloadUrl")
+    BasicAttributeSensorAndConfigKey<String> DOWNLOAD_URL = new StringAttributeSensorAndConfigKey(
+            Attributes.DOWNLOAD_URL, "https://dl.bintray.com/mitchellh/terraform/terraform_${version}_darwin_amd64.zip");
+
     @SetFromFlag("configurationContents")
-    public static final ConfigKey<String> CONFIGURATION_CONTENTS = ConfigKeys.newStringConfigKey(
+    ConfigKey<String> CONFIGURATION_CONTENTS = ConfigKeys.newStringConfigKey(
             "configuration.contents",
             "Contents of the configuration file that will be applied by Terraform.",
             "");
 
     @SetFromFlag("configurationUrl")
-    public static final ConfigKey<String> CONFIGURATION_URL = ConfigKeys.newStringConfigKey(
+    ConfigKey<String> CONFIGURATION_URL = ConfigKeys.newStringConfigKey(
             "configuration.url",
             "URL of the configuration file that will be applied by Terraform.",
             "");
+
+    AttributeSensor<Boolean> CONFIGURATION_IS_APPLIED = Sensors.newBooleanSensor("configuration.isApplied",
+            "Whether the supplied Terraform configuration has been successfully applied.");
 }

--- a/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
@@ -5,7 +5,9 @@ import java.util.Map;
 import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.annotation.Effector;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.effector.MethodEffector;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey;
@@ -48,4 +50,12 @@ public interface TerraformConfiguration extends SoftwareProcess {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     AttributeSensor<Map<String, Object>> STATE = new BasicAttributeSensor(Map.class, "state",
             "A map constructed from the state file on disk which contains the state of all managed infrastructure.");
+
+    MethodEffector<Void> APPLY = new MethodEffector<Void>(TerraformConfiguration.class, "apply");
+
+    @Effector(description="Performs the Terraform apply command which will create all of the infrastructure specified by the configuration.")
+    void apply();
+
+    @Effector(description="Performs the Terraform destroy command which will destroy all of the infrastructure that has been previously created by the configuration.")
+    void destroy();
 }

--- a/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
@@ -26,32 +26,34 @@ public interface TerraformConfiguration extends SoftwareProcess {
     BasicAttributeSensorAndConfigKey<String> DOWNLOAD_URL = new StringAttributeSensorAndConfigKey(
             Attributes.DOWNLOAD_URL, "https://dl.bintray.com/mitchellh/terraform/terraform_${version}_darwin_amd64.zip");
 
-    @SetFromFlag("configurationContents")
+    @SetFromFlag("tfConfigurationContents")
     ConfigKey<String> CONFIGURATION_CONTENTS = ConfigKeys.newStringConfigKey(
-            "configuration.contents",
+            "tf.configuration.contents",
             "Contents of the configuration file that will be applied by Terraform.",
             "");
 
-    @SetFromFlag("configurationUrl")
+    @SetFromFlag("tfConfigurationUrl")
     ConfigKey<String> CONFIGURATION_URL = ConfigKeys.newStringConfigKey(
-            "configuration.url",
+            "tf.configuration.url",
             "URL of the configuration file that will be applied by Terraform.",
             "");
 
-    AttributeSensor<Boolean> CONFIGURATION_IS_APPLIED = Sensors.newBooleanSensor("configuration.isApplied",
+    AttributeSensor<Boolean> CONFIGURATION_IS_APPLIED = Sensors.newBooleanSensor("tf.configuration.isApplied",
             "Whether the supplied Terraform configuration has been successfully applied.");
 
-    AttributeSensor<String> SHOW = Sensors.newStringSensor("show",
+    AttributeSensor<String> SHOW = Sensors.newStringSensor("tf.show",
             "The contents of the Terraform show command which provides a human-readable view of the state of the configuration.");
 
-    AttributeSensor<String> PLAN = Sensors.newStringSensor("plan",
+    AttributeSensor<String> PLAN = Sensors.newStringSensor("tf.plan",
             "The contents of the Terraform plan command which specifies exactly what actions will be taken upon applying the configuration.");
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    AttributeSensor<Map<String, Object>> STATE = new BasicAttributeSensor(Map.class, "state",
+    AttributeSensor<Map<String, Object>> STATE = new BasicAttributeSensor(Map.class, "tf.state",
             "A map constructed from the state file on disk which contains the state of all managed infrastructure.");
 
     MethodEffector<Void> APPLY = new MethodEffector<Void>(TerraformConfiguration.class, "apply");
+
+    MethodEffector<Void> DESTROY = new MethodEffector<Void>(TerraformConfiguration.class, "destroy");
 
     @Effector(description="Performs the Terraform apply command which will create all of the infrastructure specified by the configuration.")
     void apply();

--- a/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
@@ -35,4 +35,10 @@ public interface TerraformConfiguration extends SoftwareProcess {
 
     AttributeSensor<Boolean> CONFIGURATION_IS_APPLIED = Sensors.newBooleanSensor("configuration.isApplied",
             "Whether the supplied Terraform configuration has been successfully applied.");
+
+    AttributeSensor<String> SHOW = Sensors.newStringSensor("show",
+            "The contents of the Terraform show command which provides a human-readable view of the state of the configuration.");
+
+    AttributeSensor<String> PLAN = Sensors.newStringSensor("plan",
+            "The contents of the Terraform plan command which specifies exactly what actions will be taken upon applying the configuration.");
 }

--- a/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
@@ -1,10 +1,13 @@
 package io.cloudsoft.terraform;
 
+import java.util.Map;
+
 import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey.StringAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.Sensors;
@@ -41,4 +44,8 @@ public interface TerraformConfiguration extends SoftwareProcess {
 
     AttributeSensor<String> PLAN = Sensors.newStringSensor("plan",
             "The contents of the Terraform plan command which specifies exactly what actions will be taken upon applying the configuration.");
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    AttributeSensor<Map<String, Object>> STATE = new BasicAttributeSensor(Map.class, "state",
+            "A map constructed from the state file on disk which contains the state of all managed infrastructure.");
 }

--- a/src/main/java/io/cloudsoft/terraform/TerraformConfigurationImpl.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfigurationImpl.java
@@ -1,8 +1,18 @@
 package io.cloudsoft.terraform;
 
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
+import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
 import org.apache.brooklyn.feed.ssh.SshFeed;
+import org.apache.brooklyn.feed.ssh.SshPollConfig;
+import org.apache.brooklyn.feed.ssh.SshPollValue;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.text.Strings;
+import org.apache.brooklyn.util.time.Duration;
+
+import com.google.common.base.Function;
 
 public class TerraformConfigurationImpl extends SoftwareProcessImpl implements TerraformConfiguration {
 
@@ -19,27 +29,53 @@ public class TerraformConfigurationImpl extends SoftwareProcessImpl implements T
         super.connectSensors();
         connectServiceUpIsRunning();
 
-//        Maybe<SshMachineLocation> machine = Locations.findUniqueSshMachineLocation(getLocations());
-//        if (machine.isPresent()) {
-//            sshFeed = SshFeed.builder()
-//                    .entity(this)
-//                    .period(Duration.PRACTICALLY_FOREVER)
-//                    .machine(machine.get())
-//                    .poll(new SshPollConfig<Boolean>(CONFIGURATION_IS_VALID)
-//                            .command(getDriver().makeTerraformCommand("plan"))
-//                            .onSuccess(new Function<SshPollValue, Boolean>() {
+        Maybe<SshMachineLocation> machine = Locations.findUniqueSshMachineLocation(getLocations());
+        if (machine.isPresent()) {
+            sshFeed = SshFeed.builder()
+                    .entity(this)
+                    .period(Duration.TEN_SECONDS)
+                    .machine(machine.get())
+                    .poll(new SshPollConfig<String>(SHOW)
+                            .command(getDriver().makeTerraformCommand("show"))
+                            .onSuccess(new Function<SshPollValue, String>() {
+                                @Override
+                                public String apply(SshPollValue input) {
+                                    return input.getStdout();
+                                }})
+                            .onFailure(new Function<SshPollValue, String>() {
+                                @Override
+                                public String apply(SshPollValue input) {
+                                    ServiceStateLogic.setExpectedState(TerraformConfigurationImpl.this, Lifecycle.ON_FIRE);
+                                    return input.getStderr();
+                                }}))
+//                    .poll(new SshPollConfig<String>(STATE)
+//                            .command(getDriver().makeTerraformCommand("state"))
+//                            .onSuccess(new Function<SshPollValue, String>() {
 //                                @Override
-//                                public Boolean apply(SshPollValue input) {
-//                                    return true;
+//                                public String apply(SshPollValue input) {
+//                                    return input.getStdout();
 //                                }})
-//                            .onFailure(new Function<SshPollValue, Boolean>() {
+//                            .onFailure(new Function<SshPollValue, String>() {
 //                                @Override
-//                                public Boolean apply(SshPollValue input) {
+//                                public String apply(SshPollValue input) {
 //                                    ServiceStateLogic.setExpectedState(TerraformConfigurationImpl.this, Lifecycle.ON_FIRE);
-//                                    return false;
+//                                    return input.getStderr();
 //                                }}))
-//                    .build();
-//        }
+                    .poll(new SshPollConfig<String>(PLAN)
+                            .command(getDriver().makeTerraformCommand("plan"))
+                            .onSuccess(new Function<SshPollValue, String>() {
+                                @Override
+                                public String apply(SshPollValue input) {
+                                    return input.getStdout();
+                                }})
+                            .onFailure(new Function<SshPollValue, String>() {
+                                @Override
+                                public String apply(SshPollValue input) {
+                                    ServiceStateLogic.setExpectedState(TerraformConfigurationImpl.this, Lifecycle.ON_FIRE);
+                                    return input.getStderr();
+                                }}))
+                    .build();
+        }
     }
 
     @Override

--- a/src/main/java/io/cloudsoft/terraform/TerraformConfigurationImpl.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfigurationImpl.java
@@ -1,9 +1,12 @@
 package io.cloudsoft.terraform;
 
 import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
+import org.apache.brooklyn.feed.ssh.SshFeed;
 import org.apache.brooklyn.util.text.Strings;
 
 public class TerraformConfigurationImpl extends SoftwareProcessImpl implements TerraformConfiguration {
+
+    private SshFeed sshFeed;
 
     @Override
     public void init() {
@@ -15,6 +18,35 @@ public class TerraformConfigurationImpl extends SoftwareProcessImpl implements T
     protected void connectSensors() {
         super.connectSensors();
         connectServiceUpIsRunning();
+
+//        Maybe<SshMachineLocation> machine = Locations.findUniqueSshMachineLocation(getLocations());
+//        if (machine.isPresent()) {
+//            sshFeed = SshFeed.builder()
+//                    .entity(this)
+//                    .period(Duration.PRACTICALLY_FOREVER)
+//                    .machine(machine.get())
+//                    .poll(new SshPollConfig<Boolean>(CONFIGURATION_IS_VALID)
+//                            .command(getDriver().makeTerraformCommand("plan"))
+//                            .onSuccess(new Function<SshPollValue, Boolean>() {
+//                                @Override
+//                                public Boolean apply(SshPollValue input) {
+//                                    return true;
+//                                }})
+//                            .onFailure(new Function<SshPollValue, Boolean>() {
+//                                @Override
+//                                public Boolean apply(SshPollValue input) {
+//                                    ServiceStateLogic.setExpectedState(TerraformConfigurationImpl.this, Lifecycle.ON_FIRE);
+//                                    return false;
+//                                }}))
+//                    .build();
+//        }
+    }
+
+    @Override
+    public void disconnectSensors() {
+        disconnectServiceUpIsRunning();
+        if (sshFeed != null) sshFeed.stop();
+        super.disconnectSensors();
     }
 
     private void checkConfiguration() {
@@ -30,5 +62,10 @@ public class TerraformConfigurationImpl extends SoftwareProcessImpl implements T
     @Override
     public Class<?> getDriverInterface() {
         return TerraformDriver.class;
+    }
+
+    @Override
+    public TerraformDriver getDriver() {
+        return (TerraformDriver) super.getDriver();
     }
 }

--- a/src/main/java/io/cloudsoft/terraform/TerraformConfigurationImpl.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfigurationImpl.java
@@ -51,7 +51,7 @@ public class TerraformConfigurationImpl extends SoftwareProcessImpl implements T
         super.connectSensors();
         connectServiceUpIsRunning();
 
-        functionFeed = FunctionFeed.builder()
+        addFeed(functionFeed = FunctionFeed.builder()
             .entity(this)
             .period(FEED_UPDATE_PERIOD)
             .poll(new FunctionPollConfig<Object, Boolean>(CONFIGURATION_IS_APPLIED)
@@ -61,11 +61,11 @@ public class TerraformConfigurationImpl extends SoftwareProcessImpl implements T
                         return configurationIsApplied.get();
                     }
                 }))
-            .build();
+            .build());
 
         Maybe<SshMachineLocation> machine = Locations.findUniqueSshMachineLocation(getLocations());
         if (machine.isPresent()) {
-            sshFeed = SshFeed.builder()
+            addFeed(sshFeed = SshFeed.builder()
                 .entity(this)
                 .period(FEED_UPDATE_PERIOD)
                 .machine(machine.get())
@@ -129,7 +129,7 @@ public class TerraformConfigurationImpl extends SoftwareProcessImpl implements T
                             else
                                 return input.getStderr();
                         }}))
-                .build();
+                .build());
         }
     }
 

--- a/src/main/java/io/cloudsoft/terraform/TerraformConfigurationImpl.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfigurationImpl.java
@@ -32,9 +32,9 @@ public class TerraformConfigurationImpl extends SoftwareProcessImpl implements T
 
     private FunctionFeed functionFeed;
 
-    private final Map<String, Object> lastCommandOutputs = Collections.synchronizedMap(Maps.<String, Object> newHashMapWithExpectedSize(3));
+    private Map<String, Object> lastCommandOutputs = Collections.synchronizedMap(Maps.<String, Object> newHashMapWithExpectedSize(3));
 
-    private final AtomicBoolean configurationChangeInProgress = new AtomicBoolean(false);
+    private AtomicBoolean configurationChangeInProgress = new AtomicBoolean(false);
 
     @Override
     public void init() {
@@ -45,7 +45,6 @@ public class TerraformConfigurationImpl extends SoftwareProcessImpl implements T
             setConfigurationApplied(false);
     }
 
-
     private void checkConfiguration() {
         String configurationUrl = getConfig(CONFIGURATION_URL);
         String configurationContents = getConfig(CONFIGURATION_CONTENTS);
@@ -54,6 +53,14 @@ public class TerraformConfigurationImpl extends SoftwareProcessImpl implements T
         if (Strings.isBlank(configurationUrl) == Strings.isBlank(configurationContents))
             throw new IllegalArgumentException("Exactly one of the two must have a value: '"
                     + CONFIGURATION_URL.getName() + "' or '" + CONFIGURATION_CONTENTS.getName() + "'.");
+    }
+
+    @Override
+    public void rebind() {
+        lastCommandOutputs = Collections.synchronizedMap(Maps.<String, Object> newHashMapWithExpectedSize(3));
+        configurationChangeInProgress = new AtomicBoolean(false);
+
+        super.rebind();
     }
 
     @Override

--- a/src/main/java/io/cloudsoft/terraform/TerraformConfigurationImpl.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfigurationImpl.java
@@ -44,7 +44,7 @@ public class TerraformConfigurationImpl extends SoftwareProcessImpl implements T
                     .period(Duration.seconds(30))
                     .machine(machine.get())
                     .poll(new SshPollConfig<String>(SHOW)
-                            .command(getDriver().makeTerraformCommand("show"))
+                            .command(getDriver().makeTerraformCommand("show -no-color"))
                             .onSuccess(new Function<SshPollValue, String>() {
                                 @Override
                                 public String apply(SshPollValue input) {
@@ -57,7 +57,7 @@ public class TerraformConfigurationImpl extends SoftwareProcessImpl implements T
                                     return input.getStderr();
                                 }}))
                     .poll(new SshPollConfig<Map<String, Object>>(STATE)
-                            .command(getDriver().makeTerraformCommand("refresh"))
+                            .command(getDriver().makeTerraformCommand("refresh -no-color"))
                             .onSuccess(new Function<SshPollValue, Map<String, Object>>() {
                                 @Override
                                 public Map<String, Object> apply(SshPollValue input) {
@@ -73,7 +73,7 @@ public class TerraformConfigurationImpl extends SoftwareProcessImpl implements T
                                     return ImmutableMap.<String, Object> of("ERROR", "Failed to refresh state.");
                                 }}))
                     .poll(new SshPollConfig<String>(PLAN)
-                            .command(getDriver().makeTerraformCommand("plan"))
+                            .command(getDriver().makeTerraformCommand("plan -no-color"))
                             .onSuccess(new Function<SshPollValue, String>() {
                                 @Override
                                 public String apply(SshPollValue input) {
@@ -119,7 +119,7 @@ public class TerraformConfigurationImpl extends SoftwareProcessImpl implements T
     @Override
     @Effector(description="Performs the Terraform apply command which will create all of the infrastructure specified by the configuration.")
     public void apply() {
-        String command = getDriver().makeTerraformCommand("apply");
+        String command = getDriver().makeTerraformCommand("apply -no-color");
         SshMachineLocation machine = Locations.findUniqueSshMachineLocation(getLocations()).get();
 
         ProcessTaskWrapper<Object> task = SshEffectorTasks.ssh(command)

--- a/src/main/java/io/cloudsoft/terraform/TerraformConfigurationImpl.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfigurationImpl.java
@@ -1,11 +1,34 @@
 package io.cloudsoft.terraform;
 
 import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
+import org.apache.brooklyn.util.text.Strings;
 
 public class TerraformConfigurationImpl extends SoftwareProcessImpl implements TerraformConfiguration {
 
     @Override
+    public void init() {
+        super.init();
+        checkConfiguration();
+    }
+
+    @Override
+    protected void connectSensors() {
+        super.connectSensors();
+        connectServiceUpIsRunning();
+    }
+
+    private void checkConfiguration() {
+        String configurationUrl = getConfig(CONFIGURATION_URL);
+        String configurationContents = getConfig(CONFIGURATION_CONTENTS);
+
+        // Exactly one of the two must have a value
+        if (Strings.isBlank(configurationUrl) == Strings.isBlank(configurationContents))
+            throw new IllegalArgumentException("Exactly one of the two must have a value: '"
+                    + CONFIGURATION_URL.getName() + "' or '" + CONFIGURATION_CONTENTS.getName() + "'.");
+    }
+
+    @Override
     public Class<?> getDriverInterface() {
-        return TerraformConfiguration.class;
+        return TerraformDriver.class;
     }
 }

--- a/src/main/java/io/cloudsoft/terraform/TerraformDriver.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformDriver.java
@@ -1,8 +1,16 @@
 package io.cloudsoft.terraform;
 
+import java.io.IOException;
+import java.util.Map;
+
 import org.apache.brooklyn.entity.software.base.SoftwareProcessDriver;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 
 public interface TerraformDriver extends SoftwareProcessDriver {
 
     String makeTerraformCommand(String argument);
+
+    Map<String, Object> getState() throws JsonParseException, JsonMappingException, IOException;
 }

--- a/src/main/java/io/cloudsoft/terraform/TerraformDriver.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformDriver.java
@@ -4,4 +4,5 @@ import org.apache.brooklyn.entity.software.base.SoftwareProcessDriver;
 
 public interface TerraformDriver extends SoftwareProcessDriver {
 
+    String makeTerraformCommand(String argument);
 }

--- a/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
@@ -46,7 +46,7 @@ public class TerraformSshDriver extends JavaSoftwareProcessSshDriver implements 
 
     @Override
     public void stop() {
-        // TODO Auto-generated method stub
+        ((TerraformConfiguration) entity).destroy();
     }
 
     @Override
@@ -84,7 +84,7 @@ public class TerraformSshDriver extends JavaSoftwareProcessSshDriver implements 
 
     @Override
     public void launch() {
-        // TODO Auto-generated method stub
+        ((TerraformConfiguration) entity).apply();
     }
 
     private boolean copyConfiguration() {

--- a/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
@@ -79,7 +79,7 @@ public class TerraformSshDriver extends JavaSoftwareProcessSshDriver implements 
             throw new IllegalStateException("No Terraform configuration could be resolved.");
 
         //TODO Display meaningful message indicating that the config file is invalid
-        newScript(CUSTOMIZING).updateTaskAndFailOnNonZeroResultCode().body.append(makeTerraformCommand("plan")).execute();
+        newScript(CUSTOMIZING).updateTaskAndFailOnNonZeroResultCode().body.append(makeTerraformCommand("plan -no-color")).execute();
     }
 
     @Override

--- a/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
@@ -3,9 +3,13 @@ package io.cloudsoft.terraform;
 import static java.lang.String.format;
 import static org.apache.brooklyn.util.ssh.BashCommands.commandsToDownloadUrlsAs;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.core.entity.Entities;
@@ -17,6 +21,9 @@ import org.apache.brooklyn.util.ssh.BashCommands;
 import org.apache.brooklyn.util.stream.KnownSizeInputStream;
 import org.apache.brooklyn.util.text.Strings;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
@@ -105,8 +112,18 @@ public class TerraformSshDriver extends JavaSoftwareProcessSshDriver implements 
         return getRunDir() + "/configuration.tf";
     }
 
+    private String getStateFilePath() {
+        return getRunDir() + "/terraform.tfstate";
+    }
+
     @Override
     public String makeTerraformCommand(String argument) {
         return format("cd %s && %s/terraform %s", getRunDir(), getInstallDir(), argument);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Map<String, Object> getState() throws JsonParseException, JsonMappingException, IOException {
+        return ImmutableMap.copyOf(new ObjectMapper().readValue(new File(getStateFilePath()), LinkedHashMap.class));
     }
 }

--- a/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
@@ -1,10 +1,21 @@
 package io.cloudsoft.terraform;
 
+import java.io.InputStream;
+
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.entity.java.JavaSoftwareProcessSshDriver;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.util.core.ResourceUtils;
+import org.apache.brooklyn.util.stream.KnownSizeInputStream;
+import org.apache.brooklyn.util.text.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
 
 public class TerraformSshDriver extends JavaSoftwareProcessSshDriver implements TerraformDriver {
+
+    private static final Logger log = LoggerFactory.getLogger(TerraformSshDriver.class);
 
     public TerraformSshDriver(EntityLocal entity, SshMachineLocation machine) {
         super(entity, machine);
@@ -12,8 +23,7 @@ public class TerraformSshDriver extends JavaSoftwareProcessSshDriver implements 
 
     @Override
     public boolean isRunning() {
-        // TODO Auto-generated method stub
-        return false;
+        return true;
     }
 
     @Override
@@ -25,24 +35,50 @@ public class TerraformSshDriver extends JavaSoftwareProcessSshDriver implements 
     @Override
     public void stop() {
         // TODO Auto-generated method stub
-        
     }
 
     @Override
     public void install() {
-        // TODO Auto-generated method stub
-        
+        log.info("Terraform CLI assumed to be installed -- taking no action.");
     }
 
     @Override
     public void customize() {
-        // TODO Auto-generated method stub
-        
+      //Create the directory
+        newScript(CUSTOMIZING).execute();
+
+        boolean hasConfiguration = copyConfiguration();
+        if (!hasConfiguration)
+            throw new IllegalStateException("No Terraform configuration could be resolved.");
     }
 
     @Override
     public void launch() {
         // TODO Auto-generated method stub
-        
+    }
+
+    private boolean copyConfiguration() {
+        Optional<? extends InputStream> configuration = getConfiguration();
+        if (!configuration.isPresent())
+            return false;
+
+        getMachine().copyTo(configuration.get(), getConfigurationFilePath());
+        return true;
+    }
+
+    private Optional<? extends InputStream> getConfiguration() {
+        String configurationUrl = entity.getConfig(TerraformConfiguration.CONFIGURATION_URL);
+        if (!Strings.isBlank(configurationUrl))
+            return Optional.of(new ResourceUtils(entity).getResourceFromUrl(configurationUrl));
+
+        String configurationContents = entity.getConfig(TerraformConfiguration.CONFIGURATION_CONTENTS);
+        if (!Strings.isBlank(configurationContents))
+            return Optional.of(KnownSizeInputStream.of(configurationContents));
+
+        return Optional.absent();
+    }
+
+    private String getConfigurationFilePath() {
+        return getRunDir() + "/configuration.tf";
     }
 }


### PR DESCRIPTION
The Terraform entity can apply and destroy a configuration via its effectors, and reports back the state of its managed infrastructure via its sensors.

TODO: Improve error feedback and lifecycle management.
