### PR TITLE
Don't parse plan until launch - not all files might be available yet.

### DIFF
--- a/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
@@ -77,9 +77,6 @@ public class TerraformSshDriver extends JavaSoftwareProcessSshDriver implements 
         boolean hasConfiguration = copyConfiguration();
         if (!hasConfiguration)
             throw new IllegalStateException("No Terraform configuration could be resolved.");
-
-        //TODO Display meaningful message indicating that the config file is invalid
-        newScript(CUSTOMIZING).updateTaskAndFailOnNonZeroResultCode().body.append(makeTerraformCommand("plan -no-color")).execute();
     }
 
     @Override


### PR DESCRIPTION
Additional configuration files can be uploaded using files.runtime after the customize step.
