### PR TITLE
Fix for reading the state - the terraform.tfstate is on the remote machine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.apache.brooklyn</groupId>
     <artifactId>brooklyn-downstream-parent</artifactId>
-    <version>0.8.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+    <version>0.9.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
   </parent>
 
   <groupId>io.cloudsoft.terraform</groupId>


### PR DESCRIPTION
Also bring back validating the configuration - apply was successful even when there was missing config (region).
